### PR TITLE
added day header format

### DIFF
--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -13,6 +13,10 @@ const Calendar = () => {
                 center: 'title',
                 right: 'dayGridMonth,timeGridWeek,timeGridDay'
               }}
+            dayHeaderFormat={{
+                weekday: 'short',
+                day: 'numeric'
+            }}
         />
     )
 }


### PR DESCRIPTION
Used fullcalendar's dayHeaderFormat setting to drop month from column names

[trello card](https://trello.com/c/sCizMxSy)