### PR TITLE
Bug: Fix dev script for cmd compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-demo": "dotenv -e demo.env craco build",
     "eject": "react-scripts eject",
     "lint": "eslint .",
-    "dev": "nodemon -w craco.config.js -w ./style.less --exec 'craco start'",
+    "dev": "nodemon -w craco.config.js -w ./style.less --exec \"craco start\"",
     "start": "craco start",
     "test": "craco test"
   },


### PR DESCRIPTION
The `yarn dev` script wasn't working in `cmd.exe` on Windows.
This change corrects that. It was already tested by Tim Dill.