### PR TITLE
create generic modal system for application

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,0 +1,21 @@
+import { Modal as AntdModal } from 'antd';
+import { connect } from 'react-redux';
+import { closeModal } from '../../redux/actions';
+
+const Modal = ({ content, isOpen, closeModal, config }) => {
+  console.log('modal info', { content, isOpen, closeModal });
+  console.log(config);
+  return (
+    <AntdModal
+      visible={isOpen}
+      destroyOnClose={true}
+      onCancel={closeModal}
+      footer={null}
+      {...config}
+    >
+      {content}
+    </AntdModal>
+  );
+};
+
+export default connect(({ modal }) => ({ ...modal }), { closeModal })(Modal);

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -4,6 +4,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import storeRedux from '../redux/store';
 import '../style.less';
 import MainLayout from './MainLayout';
+import Modal from '../components/Modal/Modal';
 
 const store = storeRedux();
 
@@ -13,6 +14,7 @@ const App = () => {
       <Router>
         <div className="App">
           <MainLayout />
+          <Modal />
         </div>
       </Router>
     </Provider>

--- a/src/redux/Modal.redux/Modal.actions.js
+++ b/src/redux/Modal.redux/Modal.actions.js
@@ -1,0 +1,40 @@
+import {
+  OPEN_MODAL,
+  CLOSE_MODAL,
+  SET_CONTENT,
+  CREATE_MODAL,
+  SET_CONFIG,
+} from './Modal.types';
+
+export const openModal = () => {
+  return {
+    type: OPEN_MODAL,
+  };
+};
+
+export const closeModal = () => {
+  return {
+    type: CLOSE_MODAL,
+  };
+};
+
+export const setContent = (content) => {
+  return {
+    type: SET_CONTENT,
+    payload: content,
+  };
+};
+
+export const createModal = (content, config = {}) => {
+  return {
+    type: CREATE_MODAL,
+    payload: { content, config },
+  };
+};
+
+export const setConfig = (config) => {
+  return {
+    type: SET_CONFIG,
+    payload: config,
+  };
+};

--- a/src/redux/Modal.redux/Modal.reducer.js
+++ b/src/redux/Modal.redux/Modal.reducer.js
@@ -1,0 +1,47 @@
+import {
+  OPEN_MODAL,
+  CLOSE_MODAL,
+  SET_CONTENT,
+  CREATE_MODAL,
+  SET_CONFIG,
+} from './Modal.types';
+
+const initialState = {
+  isOpen: false,
+  content: null,
+  config: {},
+};
+
+export const modal = (state = initialState, action) => {
+  switch (action.type) {
+    case CREATE_MODAL:
+      return {
+        ...state,
+        isOpen: true,
+        content: action.payload.content,
+        config: action.payload.config,
+      };
+    case OPEN_MODAL:
+      return {
+        ...state,
+        isOpen: true,
+      };
+    case CLOSE_MODAL:
+      return {
+        ...state,
+        isOpen: false,
+      };
+    case SET_CONTENT:
+      return {
+        ...state,
+        content: action.payload,
+      };
+    case SET_CONFIG:
+      return {
+        ...state,
+        config: action.payload,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/redux/Modal.redux/Modal.types.js
+++ b/src/redux/Modal.redux/Modal.types.js
@@ -1,0 +1,5 @@
+export const OPEN_MODAL = 'OPEN_MODAL';
+export const CLOSE_MODAL = 'CLOSE_MODAL';
+export const SET_CONTENT = 'SET_CONTENT';
+export const CREATE_MODAL = 'CREATE_MODAL';
+export const SET_CONFIG = 'SET_CONFIG';

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -14,3 +14,4 @@ export * from '../User.redux/User.actions';
 export * from '../Registration.redux/Registration.actions';
 export * from '../Newsletter.redux/Newsletter.actions';
 export * from '../MenteeRegistration.redux/MenteeRegistration.actions';
+export * from '../Modal.redux/Modal.actions';

--- a/src/redux/rootReducer.js
+++ b/src/redux/rootReducer.js
@@ -6,6 +6,7 @@ import { isError } from './IsError.redux/IsError.reducer';
 import { authToken } from './AuthToken.redux/AuthToken.reducer';
 import { sessionSlot } from './SessionSlot.redux/SessionSlot.reducer';
 import { registrationForm } from './Registration.redux/RegistrationForm.reducer';
+import { modal } from './Modal.redux/Modal.reducer';
 
 /**
  * Exports all reducers as a single combined reducer
@@ -17,6 +18,7 @@ const rootReducer = combineReducers({
   sessionSlot,
   user,
   registrationForm,
+  modal,
 });
 
 export default rootReducer;


### PR DESCRIPTION
The app requires several of its components to be mounted inside of modals. Each time a modal needed to be created, it required each of the invoking components to handle the opening and closing logic by themselves. This seems inefficient and poorly abstracted.

This pull attempts to use redux to create a more generic modal system for the entire app. Opening and closing logic is handled internally (though remains customizable if needed). The invoking components only need to concern themselves with what should be displayed inside the modal, not how to do it.

Currently, this system assumes that only a single modal needs to be active at any given time. If those requirements change, it should be possible to expand it to allow multiple modals to be layered on top of one another.